### PR TITLE
Add default case for switch statements

### DIFF
--- a/rm-ext/deployment/src/main/java/com/amadeus/middleware/odyssey/reactive/messaging/quarkus/rm/deployment/RmExtProcessorHelpers.java
+++ b/rm-ext/deployment/src/main/java/com/amadeus/middleware/odyssey/reactive/messaging/quarkus/rm/deployment/RmExtProcessorHelpers.java
@@ -121,6 +121,11 @@ public class RmExtProcessorHelpers {
         return char.class;
       case "void":
         return void.class;
+      //missing default case
+      default:
+         // add default case
+        break;
+
     }
     try {
       return Class.forName(className, false, cl);


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html