### PR TITLE
Add default case for switch statements

### DIFF
--- a/reactive-messaging/src/main/java/com/amadeus/middleware/odyssey/reactive/messaging/core/reactive/ReactiveStreamBuilderVisitor.java
+++ b/reactive-messaging/src/main/java/com/amadeus/middleware/odyssey/reactive/messaging/core/reactive/ReactiveStreamBuilderVisitor.java
@@ -64,6 +64,11 @@ class ReactiveStreamBuilderVisitor extends AbstractVisitor {
       case PUBLISHER_PUBLISHER:
         buildPublisherPublisher(functionInvoker);
         break;
+      //missing default case
+      default:
+           // add default case
+        break;
+  
     }
 
     // if there is no child, make the subscription


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html